### PR TITLE
Increase application attachment retention

### DIFF
--- a/kafka/bin/create-topics.sh
+++ b/kafka/bin/create-topics.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# send-application: 5 days retention, 11 Mb messages
+# send-application: 30 days retention, 11 Mb messages
 /kafka/bin/kafka-topics.sh --zookeeper=$ZOOKEEPER_CONNECT --create --if-not-exists \
 		--partitions=1 --replication-factor=1 --topic=send-application
 /kafka/bin/kafka-configs.sh --zookeeper=$ZOOKEEPER_CONNECT --alter --entity-type=topics \
-    --entity-name=send-application --add-config 'cleanup.policy=delete,retention.ms=432000000,max.message.bytes=11534336'
+    --entity-name=send-application --add-config 'cleanup.policy=delete,retention.ms=2592000000,max.message.bytes=11534336'
 
 # send-confirmation: 5 days retention, 1 Mb messages
 /kafka/bin/kafka-topics.sh --zookeeper=$ZOOKEEPER_CONNECT --create --if-not-exists \


### PR DESCRIPTION
Attachments stored in Kafka were stored for only 5 days. Here, we
increase the storage duration to 30 days, which should use ~45Gb of disk
space.