### PR TITLE
Fix 502 uwsgi error "invalid request block size"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,5 @@ CMD uwsgi --module=config.wsgi:application \
     --max-requests=5000 \
     --enable-threads \
     --logto /var/log/uwsgi/uwsgi.log \
-    --log-date
+    --log-date \
+    --buffer-size 32000


### PR DESCRIPTION
Displaying the embed demo form was failing for some users. I suspect
this was due to large request headers, which in turn was causing uwsgi
to trigger the following error:

    invalid request block size: 4301 (max 4092)...skip

The large request headers were caused by Google Analytics + Hotjar
cookies.

See explanations:
https://stackoverflow.com/questions/15878176/uwsgi-invalid-request-block-size
https://uwsgi-docs.readthedocs.io/en/latest/ThingsToKnow.html