### PR TITLE
make travis-ci test docker image building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 language: python
 python:
   - 3.6
@@ -11,6 +11,7 @@ cache: pip
 env:
   - POSTGRESQL_USER=postgres POSTGRESQL_PASSWORD=""
 services:
+  - docker
   - postgresql
   - redis
 before_script:
@@ -19,3 +20,4 @@ install:
   - pip install -r requirements/dev.txt
 script:
   - make test
+  - make build


### PR DESCRIPTION
We would have realised it earlier that the kafka image was no longer
up-to-date if docker builds were also tested as part of the travis-ci
tests.