### PR TITLE
Change postgres and redis local ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ config/settings/local.py
 .coverage
 htmlcov/
 node_modules/
+
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ config/settings/local.py
 htmlcov/
 node_modules/
 
-.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
       - postgresql-client-common
 cache: pip
 env:
-  - POSTGRESQL_USER=postgres POSTGRESQL_PASSWORD=""
+  - POSTGRES_USER=postgres POSTGRES_PASSWORD=""
 services:
   - docker
   - postgresql

--- a/README.md
+++ b/README.md
@@ -52,15 +52,28 @@ Je Postule depends on several services. To start these services, run:
 - [Kafka](http://kafka.apache.org/): a messaging queue to process tasks asynchronously. Messages are sorted in different topics and processed by consumers.
 - [Redis](https://redis.io): we use this key-value store to enforce per-address email rate limits. There is no strong resilience constraint on the data stored in redis.
 
-You can change Docker default ports mapping by using custom host ports. To do this, use an [`.env`](https://docs.docker.com/compose/compose-file/#variable-substitution) file containing custom environment variables to populate placeholders of `docker-compose.yml`, e.g.:
+#### Environment-specific settings
 
-    POSTGRES_HOST_PORT=5433
-    REDIS_HOST_PORT=6380
+Some settings that are likely to vary between deploys can be configured through environment variables:
 
-After modifying Docker ports, don't forget to reflect changes for Django by exporting environment variables to be used in settings, e.g.:
+    export JEPOSTULE_BASE_URL='http://127.0.0.1:8000'
 
-    export JEPOSTULE_REDIS_PORT=6380
-    export JEPOSTULE_POSTGRESQL_PORT=5433
+    export POSTGRES_PORT='5433'
+    export POSTGRES_HOST='127.0.0.1'
+    export POSTGRES_DB='jepostule'
+    export POSTGRES_USER='jepostule'
+    export POSTGRES_PASSWORD='mdp'
+
+    export REDIS_HOST='localhost'
+    export REDIS_PORT='6380'
+    export REDIS_DB='0'
+
+    export KAFKA_PORT='9092'
+    export KAFKA_BOOTSTRAP_SERVERS='localhost:9092'
+
+    export ZOOKEEPER_PORT='2181'
+
+    export JEPOSTULE_PORT='8000'
 
 #### Database migrations
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ Je Postule depends on several services. To start these services, run:
 - [Kafka](http://kafka.apache.org/): a messaging queue to process tasks asynchronously. Messages are sorted in different topics and processed by consumers.
 - [Redis](https://redis.io): we use this key-value store to enforce per-address email rate limits. There is no strong resilience constraint on the data stored in redis.
 
+You can change Docker default ports mapping by using custom host ports. To do this, use an [`.env`](https://docs.docker.com/compose/compose-file/#variable-substitution) file containing custom environment variables to populate placeholders of `docker-compose.yml`, e.g.:
+
+    POSTGRES_HOST_PORT=5433
+    REDIS_HOST_PORT=6380
+
+After modifying Docker ports, don't forget to reflect changes for Django by exporting environment variables to be used in settings, e.g.:
+
+    export JEPOSTULE_REDIS_PORT=6380
+    export JEPOSTULE_POSTGRESQL_PORT=5433
+
 #### Database migrations
 
 Apply SQL migrations and create Kakfa topics:

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -65,7 +65,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
         'HOST': os.environ.get('POSTGRESQL_HOST', '127.0.0.1'),
-        'PORT': os.environ.get('POSTGRESQL_PORT', '5433'),
+        'PORT': os.environ.get('POSTGRESQL_PORT', '5432'),
         'NAME': os.environ.get('POSTGRESQL_DB', 'jepostule'),
         'USER': os.environ.get('POSTGRESQL_USER', 'jepostule'),
         'PASSWORD': os.environ.get('POSTGRESQL_PASSWORD', 'mdp'),
@@ -177,7 +177,7 @@ LOGGING = {
 ############ JePostule-specific settings
 
 REDIS_HOST = 'localhost'
-REDIS_PORT = 6380
+REDIS_PORT = 6379
 REDIS_DB = 0
 
 JEPOSTULE_BASE_URL = 'http://127.0.0.1:8000'

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -64,11 +64,11 @@ WSGI_APPLICATION = 'config.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'HOST': os.environ.get('JEPOSTULE_POSTGRESQL_HOST', '127.0.0.1'),
-        'PORT': os.environ.get('JEPOSTULE_POSTGRESQL_PORT', '5432'),
-        'NAME': os.environ.get('JEPOSTULE_POSTGRESQL_DB', 'jepostule'),
-        'USER': os.environ.get('JEPOSTULE_POSTGRESQL_USER', 'jepostule'),
-        'PASSWORD': os.environ.get('JEPOSTULE_POSTGRESQL_PASSWORD', 'mdp'),
+        'HOST': os.environ.get('POSTGRES_HOST', '127.0.0.1'),
+        'PORT': os.environ.get('POSTGRES_PORT', '5432'),
+        'NAME': os.environ.get('POSTGRES_DB', 'jepostule'),
+        'USER': os.environ.get('POSTGRES_USER', 'jepostule'),
+        'PASSWORD': os.environ.get('POSTGRES_PASSWORD', 'mdp'),
     }
 }
 
@@ -176,9 +176,9 @@ LOGGING = {
 
 ############ JePostule-specific settings
 
-REDIS_HOST = os.environ.get('JEPOSTULE_REDIS_HOST', 'localhost')
-REDIS_PORT = os.environ.get('JEPOSTULE_REDIS_PORT', '6379')
-REDIS_DB = os.environ.get('JEPOSTULE_REDIS_DB', '0')
+REDIS_HOST = os.environ.get('REDIS_HOST', 'localhost')
+REDIS_PORT = os.environ.get('REDIS_PORT', '6379')
+REDIS_DB = os.environ.get('REDIS_DB', '0')
 
 JEPOSTULE_BASE_URL = os.environ.get('JEPOSTULE_BASE_URL', 'http://127.0.0.1:8000')
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
@@ -201,6 +201,6 @@ EVENT_CALLBACK_SECRET = None
 QUEUE_PRODUCER = 'jepostule.queue.handlers.franz.KafkaProducer'
 QUEUE_CONSUMER = 'jepostule.queue.handlers.franz.KafkaConsumer'
 QUEUE_RUN_ASYNC = True
-KAFKA_BOOTSTRAP_SERVERS = [os.environ.get('JEPOSTULE_KAFKA_BOOTSTRAP_SERVERS', 'localhost:9092')]
+KAFKA_BOOTSTRAP_SERVERS = [os.environ.get('KAFKA_BOOTSTRAP_SERVERS', 'localhost:9092')]
 
 TEST_RUNNER = 'jepostule.tests.runner.JePostuleRunner'

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -65,7 +65,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
         'HOST': os.environ.get('POSTGRESQL_HOST', '127.0.0.1'),
-        'PORT': os.environ.get('POSTGRESQL_PORT', '5432'),
+        'PORT': os.environ.get('POSTGRESQL_PORT', '5433'),
         'NAME': os.environ.get('POSTGRESQL_DB', 'jepostule'),
         'USER': os.environ.get('POSTGRESQL_USER', 'jepostule'),
         'PASSWORD': os.environ.get('POSTGRESQL_PASSWORD', 'mdp'),
@@ -177,7 +177,7 @@ LOGGING = {
 ############ JePostule-specific settings
 
 REDIS_HOST = 'localhost'
-REDIS_PORT = 6379
+REDIS_PORT = 6380
 REDIS_DB = 0
 
 JEPOSTULE_BASE_URL = 'http://127.0.0.1:8000'

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -64,11 +64,11 @@ WSGI_APPLICATION = 'config.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'HOST': os.environ.get('POSTGRESQL_HOST', '127.0.0.1'),
-        'PORT': os.environ.get('POSTGRESQL_PORT', '5432'),
-        'NAME': os.environ.get('POSTGRESQL_DB', 'jepostule'),
-        'USER': os.environ.get('POSTGRESQL_USER', 'jepostule'),
-        'PASSWORD': os.environ.get('POSTGRESQL_PASSWORD', 'mdp'),
+        'HOST': os.environ.get('JEPOSTULE_POSTGRESQL_HOST', '127.0.0.1'),
+        'PORT': os.environ.get('JEPOSTULE_POSTGRESQL_PORT', '5432'),
+        'NAME': os.environ.get('JEPOSTULE_POSTGRESQL_DB', 'jepostule'),
+        'USER': os.environ.get('JEPOSTULE_POSTGRESQL_USER', 'jepostule'),
+        'PASSWORD': os.environ.get('JEPOSTULE_POSTGRESQL_PASSWORD', 'mdp'),
     }
 }
 
@@ -176,11 +176,11 @@ LOGGING = {
 
 ############ JePostule-specific settings
 
-REDIS_HOST = 'localhost'
-REDIS_PORT = 6379
-REDIS_DB = 0
+REDIS_HOST = os.environ.get('JEPOSTULE_REDIS_HOST', 'localhost')
+REDIS_PORT = os.environ.get('JEPOSTULE_REDIS_PORT', '6379')
+REDIS_DB = os.environ.get('JEPOSTULE_REDIS_DB', '0')
 
-JEPOSTULE_BASE_URL = 'http://127.0.0.1:8000'
+JEPOSTULE_BASE_URL = os.environ.get('JEPOSTULE_BASE_URL', 'http://127.0.0.1:8000')
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 EMAIL_SENDING_MODULE = 'jepostule.email.backends.django'
 JEPOSTULE_NO_REPLY = 'contact@jepostule.labonneboite.pole-emploi.fr'
@@ -201,6 +201,6 @@ EVENT_CALLBACK_SECRET = None
 QUEUE_PRODUCER = 'jepostule.queue.handlers.franz.KafkaProducer'
 QUEUE_CONSUMER = 'jepostule.queue.handlers.franz.KafkaConsumer'
 QUEUE_RUN_ASYNC = True
-KAFKA_BOOTSTRAP_SERVERS = ['localhost:9092']
+KAFKA_BOOTSTRAP_SERVERS = [os.environ.get('JEPOSTULE_KAFKA_BOOTSTRAP_SERVERS', 'localhost:9092')]
 
 TEST_RUNNER = 'jepostule.tests.runner.JePostuleRunner'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       POSTGRES_USER: 'jepostule'
       POSTGRES_PASSWORD: 'mdp'
     ports:
-      - 5432:5432
+      - 5433:5432
     volumes:
       - postgres:/var/lib/postgresql/data
 
@@ -18,7 +18,7 @@ services:
     command: redis-server --appendonly yes
     restart: unless-stopped
     ports:
-      - 6379:6379
+      - 6380:6379
     volumes:
       - redis:/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       POSTGRES_USER: 'jepostule'
       POSTGRES_PASSWORD: 'mdp'
     ports:
-      - "${POSTGRES_HOST_PORT:-5432}:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres:/var/lib/postgresql/data
 
@@ -18,7 +18,7 @@ services:
     command: redis-server --appendonly yes
     restart: unless-stopped
     ports:
-      - "${REDIS_HOST_PORT:-6379}:6379"
+      - "${REDIS_PORT:-6379}:6379"
     volumes:
       - redis:/data
 
@@ -28,7 +28,7 @@ services:
     environment:
       ZOO_MY_ID: 1
     ports:
-      - "${ZOOKEEPER_HOST_PORT:-2181}:2181"
+      - "${ZOOKEEPER_PORT:-2181}:2181"
     volumes:
       - zookeeper_data:/data
       - zookeeper_datalog:/datalog
@@ -39,7 +39,7 @@ services:
     environment:
       LISTENERS: "${KAFKA_LISTENERS:-kafka}"
     ports:
-      - "${KAFKA_HOST_PORT:-9092}:9092"
+      - "${KAFKA_PORT:-9092}:9092"
     depends_on:
       - zookeeper
     volumes:
@@ -50,7 +50,7 @@ services:
     image: jepostule:latest
     restart: unless-stopped
     ports:
-      - "${JEPOSTULE_HOST_PORT:-8000}:8000"
+      - "${JEPOSTULE_PORT:-8000}:8000"
     depends_on:
       - kafka
       - postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       POSTGRES_USER: 'jepostule'
       POSTGRES_PASSWORD: 'mdp'
     ports:
-      - 5433:5432
+      - 5432:5432
     volumes:
       - postgres:/var/lib/postgresql/data
 
@@ -18,7 +18,7 @@ services:
     command: redis-server --appendonly yes
     restart: unless-stopped
     ports:
-      - 6380:6379
+      - 6379:6379
     volumes:
       - redis:/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       POSTGRES_USER: 'jepostule'
       POSTGRES_PASSWORD: 'mdp'
     ports:
-      - 5432:5432
+      - "${POSTGRES_HOST_PORT:-5432}:5432"
     volumes:
       - postgres:/var/lib/postgresql/data
 
@@ -18,7 +18,7 @@ services:
     command: redis-server --appendonly yes
     restart: unless-stopped
     ports:
-      - 6379:6379
+      - "${REDIS_HOST_PORT:-6379}:6379"
     volumes:
       - redis:/data
 
@@ -28,7 +28,7 @@ services:
     environment:
       ZOO_MY_ID: 1
     ports:
-      - 2181:2181
+      - "${ZOOKEEPER_HOST_PORT:-2181}:2181"
     volumes:
       - zookeeper_data:/data
       - zookeeper_datalog:/datalog
@@ -39,7 +39,7 @@ services:
     environment:
       LISTENERS: "${KAFKA_LISTENERS:-kafka}"
     ports:
-      - 9092:9092
+      - "${KAFKA_HOST_PORT:-9092}:9092"
     depends_on:
       - zookeeper
     volumes:
@@ -50,7 +50,7 @@ services:
     image: jepostule:latest
     restart: unless-stopped
     ports:
-      - 8000:8000
+      - "${JEPOSTULE_HOST_PORT:-8000}:8000"
     depends_on:
       - kafka
       - postgres


### PR DESCRIPTION
Je fais juste une PR pour discuter des changements apportés.

L'idée est de ne pas utiliser les ports par défaut de postgres et redis pour ne pas entrer en conflit avec ceux potentiellement existants.

Quel est l'impact d'un tel changement en production ?

Quelle est la meilleure solution pour opérer un tel changement ? Quels ports de rechange utiliser ?