### PR TITLE
Use pre ES2015 JavaScript to please django-pipeline

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -103,12 +103,14 @@ STATIC_ROOT = '/tmp/jepostule/static'
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, 'jepostule', 'static'),
 ]
+# https://django-pipeline.readthedocs.io/en/latest/usage.html#collect-static
 STATICFILES_STORAGE = 'pipeline.storage.PipelineStorage'
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
     'pipeline.finders.PipelineFinder',
 )
+
 # https://django-pipeline.readthedocs.io/en/latest/configuration.html
 PIPELINE = {
     'JAVASCRIPT': {

--- a/jepostule/static/js/common/localStorage.js
+++ b/jepostule/static/js/common/localStorage.js
@@ -2,22 +2,22 @@
 
 document.addEventListener('DOMContentLoaded', function () {
 
-  let useLocalStorage = inputs => {
+  var useLocalStorage = function (inputs) {
 
     if (!inputs.length) {
       return
     }
 
-    let saveToLocalStorage = (e) => {
-      let input = e.target
+    var saveToLocalStorage = function (e) {
+      var input = e.target
       if (input.value) {
         localStorage.setItem(input.name, input.value)
       }
     }
 
-    Array.from(inputs).forEach(input => {
+    inputs.forEach(function (input) {
       // Load value from local storage.
-      let value = localStorage.getItem(input.name)
+      var value = localStorage.getItem(input.name)
       if (value) {
         input.value = value
         input.dispatchEvent(new Event('change'), {'bubbles': true})

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,14 +15,14 @@
       "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
     },
     "jquery": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
     "jquery-datetimepicker": {
-      "version": "2.5.20",
-      "resolved": "https://registry.npmjs.org/jquery-datetimepicker/-/jquery-datetimepicker-2.5.20.tgz",
-      "integrity": "sha512-ugnjbUkOw1MWuJx+Aik9Reew9U2We+kGdaXU5NKvfdBNiG/vNeeFlgQ8EWu1h8zFf5wmUse7G1MLsYHTP18J4Q==",
+      "version": "2.5.21",
+      "resolved": "https://registry.npmjs.org/jquery-datetimepicker/-/jquery-datetimepicker-2.5.21.tgz",
+      "integrity": "sha512-wDTpZ4f1PWd1XGaIIE0n6jLynlm+akBJ7/NjaB1bk2UJSS593CHJPZ3+FNEXoyvNVUeBlBC0oX6WTfCyfUhX/w==",
       "requires": {
         "jquery": ">= 1.7.2",
         "jquery-mousewheel": ">= 3.1.13",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jepostule",
   "version": "0.0.1",
   "dependencies": {
-    "jquery-datetimepicker": "^2.5.20",
+    "jquery-datetimepicker": "^2.5.21",
     "yuglify": "^2.0.0",
     "tarteaucitronjs": "^1.2.0"
   },


### PR DESCRIPTION
Le déploiement en production à échoué car mon code JavaScript ne passait pas l'étape du `collectstatic` à cause de `django-pipeline` qui [par défaut](https://github.com/jazzband/django-pipeline/blob/5ec680174d1897498ec9c6652a4130bc0d39dddd/pipeline/conf.py#L29) utilise [`yuglify`](https://github.com/yui/yuglify) qui ne supporte pas la syntaxe ES2015.

J'ai perdu tellement de temps à essayer de configurer `django-pipeline` pour utiliser Babel afin de [convertir du code ES6 vers du vanilla ES5](https://django-pipeline.readthedocs.io/en/latest/compilers.html#es6-compiler)… mais j'ai lamentablement échoué…

Je n'ai pas réussi à configurer les [`BABEL_ARGUMENTS`](https://django-pipeline.readthedocs.io/en/latest/compilers.html#babel-arguments) pour leur passer le plugin [`@babel/preset-env`](https://babeljs.io/docs/en/babel-preset-env) (ni même l'ancien plugin [`@babel/preset-es2015`](https://babeljs.io/docs/en/babel-preset-es2015)) et le faire marcher avec `collectstatic` en local. Probablement à cause de [`STATIC_ROOT`](https://github.com/StartupsPoleEmploi/jepostule/blob/a382c833b0353f4ae11290048c2523d4daeb8abb/config/settings/base.py#L102) qui rassemble les *statics* dans `tmp` et qui perd le `path` des `node_modules`.

Bref c'est très énervant. Pour ne pas perdre plus de temps, je laisse le tout en l'état et je "downgrade" la syntaxe vers du code ES5.

Il y aussi une mise à jour de JQuery et de son plugin de calendrier qui fixe une faille de sécurité.

D'ailleurs je n'ai pas encore compris comment les dépendances JavaScript `node` sont mises à jour dans le script de déploiement, ni comment `yuglify` se retrouve dans l'image Docker ?