### PR TITLE
Freeze NodeJS, NPM and Python versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,32 @@
 FROM ubuntu:18.04
 
+# Environment variables
+ENV NODE_VERSION 8.10.0
+ENV NPM_VERSION 3.5.2
+ENV NVM_DIR /usr/local/nvm
+ENV NVM_VERSION 0.34.0
+ENV PATH /jepostule/node_modules/.bin/:${PATH}
+ENV DJANGO_SETTINGS_MODULE config.settings.local
+ENV LANG C.UTF-8
+
 RUN apt update -y && \
-    apt install -y python3 python3-pip postgresql-client-common npm
+    apt install -y  \
+        python3 \
+        python3-pip \
+        postgresql-client-common \
+        curl \
+        npm=$NPM_VERSION-0ubuntu4
 RUN ln -s /usr/bin/python3 /usr/local/bin/python
 RUN ln -s /usr/bin/pip3 /usr/local/bin/pip
+
+# Install NVM
+RUN mkdir $NVM_DIR
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v$NVM_VERSION/install.sh | bash
+
+# Install NodeJS with NVM
+RUN /bin/bash -c "source $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm use $NODE_VERSION"
 
 WORKDIR /jepostule
 
@@ -12,13 +35,12 @@ COPY ./requirements/ ./requirements/
 RUN pip install -r requirements/prod.txt
 
 COPY . /jepostule
-ENV PATH /jepostule/node_modules/.bin/:${PATH}
-ENV DJANGO_SETTINGS_MODULE config.settings.local
-ENV LANG C.UTF-8
-EXPOSE 8000
 
 # Install frontend requirements
 RUN npm install --unsafe-perm
+
+EXPOSE 8000
+
 
 RUN mkdir -p /var/log/uwsgi
 CMD uwsgi --module=config.wsgi:application \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,14 @@ ENV NODE_VERSION 8.10.0
 ENV NPM_VERSION 3.5.2
 ENV NVM_DIR /usr/local/nvm
 ENV NVM_VERSION 0.34.0
+ENV PYTHON_VERSION 3.6.7-1~18.04
 ENV PATH /jepostule/node_modules/.bin/:${PATH}
 ENV DJANGO_SETTINGS_MODULE config.settings.local
 ENV LANG C.UTF-8
 
 RUN apt update -y && \
     apt install -y  \
-        python3 \
+        python3=$PYTHON_VERSION \
         python3-pip \
         postgresql-client-common \
         curl \

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ On partner websites, the user can click on "Je Postule" buttons for each display
     ./manage.py consumetopics all
     ./manage.py dequeuedelayed
 
+NodeJS version: `8.10.0` (see [`Dockerfile`](/Dockerfile) and [`package.json`](/package.json)).
+Python requirements: see the [requirements](/requirements) folder. This project uses Python `3.6`.
+
 ### Install
 
 #### System dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,9 +24,9 @@
       "resolved": "https://registry.npmjs.org/jquery-datetimepicker/-/jquery-datetimepicker-2.5.21.tgz",
       "integrity": "sha512-wDTpZ4f1PWd1XGaIIE0n6jLynlm+akBJ7/NjaB1bk2UJSS593CHJPZ3+FNEXoyvNVUeBlBC0oX6WTfCyfUhX/w==",
       "requires": {
-        "jquery": ">= 1.7.2",
-        "jquery-mousewheel": ">= 3.1.13",
-        "php-date-formatter": "^1.3.4"
+        "jquery": "3.4.1",
+        "jquery-mousewheel": "3.1.13",
+        "php-date-formatter": "1.3.4"
       }
     },
     "jquery-mousewheel": {
@@ -39,7 +39,7 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
       "integrity": "sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=",
       "requires": {
-        "abbrev": "1"
+        "abbrev": "1.1.1"
       }
     },
     "php-date-formatter": {
@@ -62,8 +62,8 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
       "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
       "requires": {
-        "commander": "~2.17.1",
-        "source-map": "~0.6.1"
+        "commander": "2.17.1",
+        "source-map": "0.6.1"
       }
     },
     "ycssmin": {
@@ -76,9 +76,9 @@
       "resolved": "https://registry.npmjs.org/yuglify/-/yuglify-2.0.0.tgz",
       "integrity": "sha1-nU5a3c4g9B7fIkhuIxG2HWo/jSE=",
       "requires": {
-        "nopt": "~2.1.1",
-        "uglify-js": "^3.1.4",
-        "ycssmin": "~1.0.1"
+        "nopt": "2.1.2",
+        "uglify-js": "3.4.9",
+        "ycssmin": "1.0.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "jepostule",
   "version": "0.0.1",
+  "engineStrict": true,
+  "engines": {
+    "node": "8.10.0"
+  },
   "dependencies": {
     "jquery-datetimepicker": "^2.5.21",
     "yuglify": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "engines": {
     "node": "8.10.0"
   },
+  "private": true,
   "dependencies": {
     "jquery-datetimepicker": "^2.5.21",
     "yuglify": "^2.0.0",


### PR DESCRIPTION
They should reflect what is already live:
- NodeJS: 8.10.0
- NPM: 3.5.2
- Python: 3.6